### PR TITLE
Hotfix: 댓글 입력시 IME 오류로 마지막 글자가 전송되는 이슈 수정

### DIFF
--- a/src/components/ui/Comment/CommentForm.tsx
+++ b/src/components/ui/Comment/CommentForm.tsx
@@ -52,6 +52,8 @@ export default function CommentForm({
   };
 
   const handleEnter = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
+
     if (e.code === 'Enter' && e.ctrlKey) {
       handleSubmit(handleFormSubmit)();
     }


### PR DESCRIPTION
## 작업 내역
- 댓글 입력시 IME 오류로 마지막 글자가 전송되는 이슈 수정

## 스크린샷
<img width="282" height="234" alt="image" src="https://github.com/user-attachments/assets/56310fdf-dd10-482c-9d83-ff8db691e99e" />
