### PR TITLE
Fix: ios에서 캘린더 부모 높이가 자식 요소보다 짧게 나타나는 현상 수정

### DIFF
--- a/src/components/feature/form/TaskForm/TaskFormCalendar.tsx
+++ b/src/components/feature/form/TaskForm/TaskFormCalendar.tsx
@@ -50,7 +50,7 @@ export default function TaskFormCalendar({
             selected={value}
             defaultMonth={value}
             onSelect={handleUpdateDate}
-            className='border-primary-hover h-fit w-full min-w-auto rounded-xl border shadow-md'
+            className='border-primary-hover w-full min-w-auto rounded-xl border shadow-md'
           />
         </div>
       )}

--- a/src/components/feature/form/TaskForm/TaskFormCalendar.tsx
+++ b/src/components/feature/form/TaskForm/TaskFormCalendar.tsx
@@ -44,7 +44,7 @@ export default function TaskFormCalendar({
         className={cn({ isCalendarOpen: '[&_input]:border-primary-hover' })}
       />
       {isCalendarOpen && (
-        <div className='mt-2 w-full'>
+        <div className='mx-auto mt-2 w-full max-w-fit'>
           <Calendar
             mode='single'
             selected={value}

--- a/src/components/feature/form/TaskForm/TaskFormCalendar.tsx
+++ b/src/components/feature/form/TaskForm/TaskFormCalendar.tsx
@@ -44,13 +44,13 @@ export default function TaskFormCalendar({
         className={cn({ isCalendarOpen: '[&_input]:border-primary-hover' })}
       />
       {isCalendarOpen && (
-        <div className='border-primary-hover mt-2 w-full rounded-xl border'>
+        <div className='mt-2 w-full'>
           <Calendar
             mode='single'
             selected={value}
             defaultMonth={value}
             onSelect={handleUpdateDate}
-            className='w-full min-w-auto'
+            className='border-primary-hover h-fit w-full min-w-auto rounded-xl border shadow-md'
           />
         </div>
       )}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -43,7 +43,7 @@ function Calendar({
       classNames={{
         root: cn('w-fit', defaultClassNames.root),
         months: cn(
-          'flex gap-4 flex-col md:flex-row relative',
+          'flex gap-4 flex-col md:flex-row relative items-start',
           defaultClassNames.months,
         ),
         month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
@@ -100,7 +100,8 @@ function Calendar({
           defaultClassNames.week_number,
         ),
         day: cn(
-          'relative w-full h-full p-0 text-center group/day aspect-square select-none',
+          'relative w-full h-full p-0 text-center group/day select-none',
+          'size-12.5', // aspect-square 대신 고정 너비/높이 사용
           defaultClassNames.day,
         ),
         range_start: cn(' bg-accent', defaultClassNames.range_start),
@@ -198,7 +199,8 @@ function CalendarDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       className={cn(
-        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-text-inverse data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground dark:hover:text-accent-foreground group-data-[outside=true]/day:text-primary-inactive group-data-[today=true]/day:text-primary hover:bg-bg-secondary flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 text-[15px] leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md [&>span]:text-xs [&>span]:opacity-70',
+        'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-text-inverse data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground dark:hover:text-accent-foreground group-data-[outside=true]/day:text-primary-inactive group-data-[today=true]/day:text-primary hover:bg-bg-secondary flex size-auto w-full min-w-(--cell-size) flex-col gap-1 text-[15px] leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md [&>span]:text-xs [&>span]:opacity-70',
+        'size-12.5', // aspect-square 대신 고정 너비/높이 사용
         defaultClassNames.day,
         className,
       )}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -85,12 +85,12 @@ function Calendar({
           defaultClassNames.caption_label,
         ),
         table: 'w-full border-collapse',
-        weekdays: cn('grid grid-cols-7', defaultClassNames.weekdays),
+        weekdays: cn('grid grid-cols-7', defaultClassNames.weekdays), // flex → grid로 변경 (webkit flex aspect-ratio 높이값 계산 이슈 방지)
         weekday: cn(
           'text-muted-foreground rounded-md flex-1 font-normal text-md select-none',
           defaultClassNames.weekday,
         ),
-        week: cn('grid grid-cols-7 w-full mt-2', defaultClassNames.week),
+        week: cn('grid grid-cols-7 w-full mt-2', defaultClassNames.week), // flex → grid로 변경
         week_number_header: cn(
           'select-none',
           defaultClassNames.week_number_header,
@@ -101,7 +101,7 @@ function Calendar({
         ),
         day: cn(
           'relative w-full h-full p-0 text-center group/day select-none',
-          'aspect-square min-w-9 sm:min-w-10.5',
+          'aspect-square min-w-10.5',
           defaultClassNames.day,
         ),
         range_start: cn(' bg-accent', defaultClassNames.range_start),
@@ -200,7 +200,7 @@ function CalendarDayButton({
       data-range-middle={modifiers.range_middle}
       className={cn(
         'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-text-inverse data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground dark:hover:text-accent-foreground group-data-[outside=true]/day:text-primary-inactive group-data-[today=true]/day:text-primary hover:bg-bg-secondary flex size-auto w-full min-w-(--cell-size) flex-col gap-1 text-[15px] leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md [&>span]:text-xs [&>span]:opacity-70',
-        'aspect-square min-w-9 sm:min-w-10.5',
+        'aspect-square min-w-10.5',
         defaultClassNames.day,
         className,
       )}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -43,7 +43,7 @@ function Calendar({
       classNames={{
         root: cn('w-fit', defaultClassNames.root),
         months: cn(
-          'flex gap-4 flex-col md:flex-row relative items-start',
+          'flex gap-4 flex-col md:flex-row relative',
           defaultClassNames.months,
         ),
         month: cn('flex flex-col w-full gap-4', defaultClassNames.month),
@@ -85,14 +85,14 @@ function Calendar({
           defaultClassNames.caption_label,
         ),
         table: 'w-full border-collapse',
-        weekdays: cn('flex', defaultClassNames.weekdays),
+        weekdays: cn('grid grid-cols-7', defaultClassNames.weekdays),
         weekday: cn(
           'text-muted-foreground rounded-md flex-1 font-normal text-md select-none',
           defaultClassNames.weekday,
         ),
-        week: cn('flex w-full mt-2', defaultClassNames.week),
+        week: cn('grid grid-cols-7 w-full mt-2', defaultClassNames.week),
         week_number_header: cn(
-          'select-none w-(--cell-size)',
+          'select-none',
           defaultClassNames.week_number_header,
         ),
         week_number: cn(
@@ -101,7 +101,7 @@ function Calendar({
         ),
         day: cn(
           'relative w-full h-full p-0 text-center group/day select-none',
-          'size-12.5', // aspect-square 대신 고정 너비/높이 사용
+          'aspect-square min-w-9 sm:min-w-10.5',
           defaultClassNames.day,
         ),
         range_start: cn(' bg-accent', defaultClassNames.range_start),
@@ -200,7 +200,7 @@ function CalendarDayButton({
       data-range-middle={modifiers.range_middle}
       className={cn(
         'data-[selected-single=true]:bg-primary data-[selected-single=true]:text-text-inverse data-[range-middle=true]:bg-accent data-[range-middle=true]:text-accent-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground dark:hover:text-accent-foreground group-data-[outside=true]/day:text-primary-inactive group-data-[today=true]/day:text-primary hover:bg-bg-secondary flex size-auto w-full min-w-(--cell-size) flex-col gap-1 text-[15px] leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md [&>span]:text-xs [&>span]:opacity-70',
-        'size-12.5', // aspect-square 대신 고정 너비/높이 사용
+        'aspect-square min-w-9 sm:min-w-10.5',
         defaultClassNames.day,
         className,
       )}


### PR DESCRIPTION
## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
- iOS의 webkit 엔진이 **부모가 `flex`일 때는 자식의 `aspect-square` 스타일 계산 결과를 즉각적으로 반영하지 못하기 때문에**, 자식 요소의 계산이 다 끝나기 전에 부모 요소의 최소 높이가 먼저 결정되어 캘린더 높이가 자식 영역을 모두 감싸지 못하는 문제가 있었습니다. 
  => `flex`에서 `grid`로 캘린더 구조를 변경하고, 자식 요소인 캘린더 일자(`DayPicker의 'day' 속성` , `CalendarDayButton`)에 적용되어있던 `aspect-square`는 유지하되, 반응형에서 캘린더 크기가 너무 커지지 않도록 `min-w-10.5`를 적용했습니다.

+ 참고로 iOS에서는 크롬, 엣지 같은 타 브라우저도 사파리와 마찬가지로 webkit 엔진을 사용해야 되는 정책이 있다고 하네요,, 그래서 브라우저를 바꿔도 똑같은 문제가 발생했었습니다😂

## 전달 사항 (선택)

<!--- 공유 사항이나 논의가 필요한 부분이 있다면 적어주세요. -->

## 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/f7175236-b01b-43a7-9ea2-bb885ff29fae" alt="" width="350"/>
<img src="https://github.com/user-attachments/assets/43371d9c-5eee-452d-a6c1-5384feab79c8" alt="" width="350"/>



